### PR TITLE
Fix "unbound variable" error for empty array in bash5

### DIFF
--- a/prometheus.bash
+++ b/prometheus.bash
@@ -425,7 +425,7 @@ io::prometheus::internal::DispatchGauge() {
   local metricname="$1"
   shift
 
-  local -a label_args
+  local -a label_args=()
   local methodname=''
   while [[ $# -gt 0 ]]; do
     case "$1" in


### PR DESCRIPTION
This type of declaration causes an "unbound variable" in bash 5, a very frustrating error.
See https://stackoverflow.com/a/28058737 for more info.